### PR TITLE
fix: remove `SLACK_CHANNEL` env variable

### DIFF
--- a/.github/workflows/deploy-to-production.yaml
+++ b/.github/workflows/deploy-to-production.yaml
@@ -97,4 +97,3 @@ jobs:
         run: npm run deploy:production
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PRODUCTION_SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.PRODUCTION_SLACK_CHANNEL }}

--- a/.github/workflows/deploy-to-staging.yaml
+++ b/.github/workflows/deploy-to-staging.yaml
@@ -97,4 +97,3 @@ jobs:
         run: npm run deploy:staging
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.STAGING_SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ secrets.STAGING_SLACK_CHANNEL }}

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,7 +36,6 @@ provider:
   # These environment vars are installed into **all** functions in the service
   environment:
     SLACK_WEBHOOK_URL: ${env:SLACK_WEBHOOK_URL}
-    SLACK_CHANNEL: ${env:SLACK_CHANNEL}
 
 custom:
   commonValues:

--- a/src/api-lambda/index.ts
+++ b/src/api-lambda/index.ts
@@ -1,14 +1,6 @@
 import { APIGatewayProxyHandler, APIGatewayProxyResult } from 'aws-lambda';
 import { Notifier } from '../utils';
 
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      SLACK_CHANNEL: string;
-    }
-  }
-}
-
 interface PostBody {
   message: string;
 }
@@ -39,16 +31,13 @@ export const handler: APIGatewayProxyHandler = async event => {
       return message;
     }
 
-    await notifier.send({
-      channel: process.env.SLACK_CHANNEL,
-      text: message
-    });
+    await notifier.send({ text: message });
 
     return { statusCode: 200, body: 'message sent' };
   } catch (err: unknown) {
     console.error(err);
 
-    await notifier.sendError(err as Error, process.env.SLACK_CHANNEL);
+    await notifier.sendError(err as Error);
 
     return { statusCode: 500, body: 'oh noes!' };
   }

--- a/src/cloudwatch-lambda/index.ts
+++ b/src/cloudwatch-lambda/index.ts
@@ -7,14 +7,6 @@ import { promisify } from 'util';
 import zlib from 'zlib';
 import { Notifier } from '../utils';
 
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      SLACK_CHANNEL: string;
-    }
-  }
-}
-
 const gunzip = promisify(zlib.gunzip);
 
 const decodeCloudWatchEvent = async (
@@ -42,10 +34,7 @@ interface LogEvent {
 }
 
 const handleLog = async (event: LogEvent, notifier: Notifier) => {
-  await notifier.send({
-    channel: process.env.SLACK_CHANNEL,
-    text: `hello ${event.account}!`
-  });
+  await notifier.send({ text: `hello ${event.account}!` });
 };
 
 export const handler: CloudWatchLogsHandler = async event => {
@@ -63,6 +52,6 @@ export const handler: CloudWatchLogsHandler = async event => {
   } catch (err: unknown) {
     console.error(err);
 
-    await notifier.sendError(err as Error, process.env.SLACK_CHANNEL);
+    await notifier.sendError(err as Error);
   }
 };

--- a/src/scheduled-lambda/index.ts
+++ b/src/scheduled-lambda/index.ts
@@ -1,27 +1,16 @@
 import { ScheduledHandler } from 'aws-lambda';
 import { Notifier } from '../utils';
 
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      SLACK_CHANNEL: string;
-    }
-  }
-}
-
 export const handler: ScheduledHandler = async event => {
   console.log(event);
 
   const notifier = new Notifier();
 
   try {
-    await notifier.send({
-      channel: process.env.SLACK_CHANNEL,
-      text: 'hello world!'
-    });
+    await notifier.send({ text: 'hello world!' });
   } catch (err: unknown) {
     console.error(err);
 
-    await notifier.sendError(err as Error, process.env.SLACK_CHANNEL);
+    await notifier.sendError(err as Error);
   }
 };

--- a/src/sns-lambda/index.ts
+++ b/src/sns-lambda/index.ts
@@ -1,19 +1,8 @@
 import { SNSHandler, SNSMessage } from 'aws-lambda';
 import { Notifier } from '../utils';
 
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      SLACK_CHANNEL: string;
-    }
-  }
-}
-
 const handleSns = async (sns: SNSMessage, notifier: Notifier) => {
-  await notifier.send({
-    channel: process.env.SLACK_CHANNEL,
-    text: buildNotificationMessage(sns)
-  });
+  await notifier.send({ text: buildNotificationMessage(sns) });
 };
 
 const buildNotificationMessage = (sns: SNSMessage): string =>
@@ -39,6 +28,6 @@ export const handler: SNSHandler = async event => {
   } catch (err: unknown) {
     console.error(err);
 
-    await notifier.sendError(err as Error, process.env.SLACK_CHANNEL);
+    await notifier.sendError(err as Error);
   }
 };

--- a/src/utils/Notifier.ts
+++ b/src/utils/Notifier.ts
@@ -22,7 +22,7 @@ export class Notifier {
     return true;
   }
 
-  public async sendError(error: Error, channel: string): Promise<boolean> {
+  public async sendError(error: Error, channel?: string): Promise<boolean> {
     const message = error.stack ?? error.message;
 
     return this.send({

--- a/test/src/api-lambda/index.spec.ts
+++ b/test/src/api-lambda/index.spec.ts
@@ -33,9 +33,7 @@ const buildApiGatewayEvent = (message: string): APIGatewayProxyEvent => {
 describe('handler', () => {
   describe('when the body has a message property', () => {
     describe('when the message property is not empty', () => {
-      it('sends the message to the channel set by SLACK_CHANNEL', async () => {
-        process.env.SLACK_CHANNEL = '#my-channel';
-
+      it('sends a message to Slack', async () => {
         const message = 'hello world!';
         const event = buildApiGatewayEvent(message);
 
@@ -43,7 +41,6 @@ describe('handler', () => {
 
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockNotifier.prototype.send).toHaveBeenCalledWith({
-          channel: '#my-channel',
           text: message
         });
       });
@@ -91,10 +88,9 @@ describe('handler', () => {
 
     beforeEach(() => {
       mockNotifier.prototype.send.mockRejectedValue(error);
-      process.env.SLACK_CHANNEL = '#my-channel';
     });
 
-    it('sends the error to the channel set by SLACK_CHANNEL', async () => {
+    it('sends the error to Slack', async () => {
       jest.spyOn(console, 'error').mockImplementation(() => null);
 
       const event = buildApiGatewayEvent('my message');
@@ -102,10 +98,7 @@ describe('handler', () => {
       await handler(event, fakeContext, console.log);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(
-        error,
-        '#my-channel'
-      );
+      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(error);
     });
 
     it('returns a 500', async () => {

--- a/test/src/cloudwatch-lambda/index.spec.ts
+++ b/test/src/cloudwatch-lambda/index.spec.ts
@@ -52,9 +52,7 @@ const buildCloudWatchEvent = (
 
 describe('handler', () => {
   describe('when there are events', () => {
-    it('sends to the channel set by SLACK_CHANNEL', async () => {
-      process.env.SLACK_CHANNEL = '#my-channel';
-
+    it('sends a message to Slack', async () => {
       const event = buildCloudWatchEvent([
         {
           id: '1234567890',
@@ -67,7 +65,6 @@ describe('handler', () => {
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockNotifier.prototype.send).toHaveBeenCalledWith({
-        channel: '#my-channel',
         text: expect.any(String) as string
       });
     });
@@ -87,7 +84,6 @@ describe('handler', () => {
       accounts.forEach(account => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockNotifier.prototype.send).toHaveBeenCalledWith({
-          channel: expect.any(String) as string,
           text: `hello ${account}!`
         });
       });
@@ -112,10 +108,9 @@ describe('handler', () => {
 
     beforeEach(() => {
       mockNotifier.prototype.send.mockRejectedValue(error);
-      process.env.SLACK_CHANNEL = '#my-channel';
     });
 
-    it('sends the error to the channel set by SLACK_CHANNEL', async () => {
+    it('sends the error to Slack', async () => {
       jest.spyOn(console, 'error').mockImplementation(() => null);
 
       const event = buildCloudWatchEvent([
@@ -129,10 +124,7 @@ describe('handler', () => {
       await handler(event, fakeContext, console.log);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(
-        error,
-        '#my-channel'
-      );
+      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/test/src/scheduled-lambda/index.spec.ts
+++ b/test/src/scheduled-lambda/index.spec.ts
@@ -39,16 +39,13 @@ const buildScheduledEvent = (): ScheduledEvent => ({
 
 describe('handler', () => {
   describe('when there is an event', () => {
-    it('sends a notification to the channel set by SLACK_CHANNEL', async () => {
-      process.env.SLACK_CHANNEL = '#my-channel';
-
+    it('sends a message to Slack', async () => {
       const event = buildScheduledEvent();
 
       await handler(event, fakeContext, console.log);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockNotifier.prototype.send).toHaveBeenCalledWith({
-        channel: '#my-channel',
         text: expect.any(String) as string
       });
     });
@@ -59,10 +56,9 @@ describe('handler', () => {
 
     beforeEach(() => {
       mockNotifier.prototype.send.mockRejectedValue(error);
-      process.env.SLACK_CHANNEL = '#my-channel';
     });
 
-    it('sends the error to the channel set by SLACK_CHANNEL', async () => {
+    it('sends the error to Slack', async () => {
       jest.spyOn(console, 'error').mockImplementation(() => null);
 
       const event = buildScheduledEvent();
@@ -70,10 +66,7 @@ describe('handler', () => {
       await handler(event, fakeContext, console.log);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(
-        error,
-        '#my-channel'
-      );
+      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/test/src/sns-lambda/index.spec.ts
+++ b/test/src/sns-lambda/index.spec.ts
@@ -49,16 +49,13 @@ const buildSNSEvent = (messages: Array<Partial<SNSMessage>>): SNSEvent => ({
 
 describe('handler', () => {
   describe('when there are events', () => {
-    it('sends to the channel set by SLACK_CHANNEL', async () => {
-      process.env.SLACK_CHANNEL = '#my-channel';
-
+    it('sends a message to Slack', async () => {
       const event = buildSNSEvent([{ Message: 'hello world' }]);
 
       await handler(event, fakeContext, console.log);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockNotifier.prototype.send).toHaveBeenCalledWith({
-        channel: '#my-channel',
         text: expect.any(String) as string
       });
     });
@@ -72,7 +69,6 @@ describe('handler', () => {
       messages.forEach(message => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockNotifier.prototype.send).toHaveBeenCalledWith({
-          channel: expect.any(String) as string,
           text: expect.stringContaining(message) as string
         });
       });
@@ -95,10 +91,9 @@ describe('handler', () => {
 
     beforeEach(() => {
       mockNotifier.prototype.send.mockRejectedValue(error);
-      process.env.SLACK_CHANNEL = '#my-channel';
     });
 
-    it('sends the error to the channel set by SLACK_CHANNEL', async () => {
+    it('sends the error to Slack', async () => {
       jest.spyOn(console, 'error').mockImplementation(() => null);
 
       const event = buildSNSEvent([{ Message: 'hello world' }]);
@@ -106,10 +101,7 @@ describe('handler', () => {
       await handler(event, fakeContext, console.log);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(
-        error,
-        '#my-channel'
-      );
+      expect(mockNotifier.prototype.sendError).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/test/src/utils/Notifier.spec.ts
+++ b/test/src/utils/Notifier.spec.ts
@@ -62,11 +62,10 @@ describe('Notifier', () => {
     it('sends a message to slack with the stack trace', async () => {
       const notifier = new Notifier('https://example.com/webhook');
 
-      await notifier.sendError(new Error('oh noes!'), '#my-channel');
+      await notifier.sendError(new Error('oh noes!'));
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(fakeIncomingWebhook.prototype.send).toHaveBeenCalledWith({
-        channel: expect.stringMatching(/^#/u) as string,
         text: expect.stringContaining('oh noes!') as string
       });
     });
@@ -78,9 +77,9 @@ describe('Notifier', () => {
 
       const notifier = new Notifier('https://example.com/webhook');
 
-      await expect(
-        notifier.sendError(new Error('oh noes!'), '#my-channel')
-      ).resolves.toBe(false);
+      await expect(notifier.sendError(new Error('oh noes!'))).resolves.toBe(
+        false
+      );
     });
 
     describe("when the error doesn't have a stack", () => {
@@ -90,15 +89,29 @@ describe('Notifier', () => {
 
         delete error.stack;
 
-        await notifier.sendError(error, '#my-channel');
+        await notifier.sendError(error);
 
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(fakeIncomingWebhook.prototype.send).toHaveBeenCalledWith({
-          channel: expect.stringMatching(/^#/u) as string,
           text: expect.stringContaining(
             "oh noes, we don't have a stack trace!"
           ) as string
         });
+      });
+    });
+
+    describe('when a channel is provided', () => {
+      it('sends the message to that channel', async () => {
+        const notifier = new Notifier('https://example.com/webhook');
+
+        await notifier.sendError(new Error('oh noes!'), '#my-channel');
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(fakeIncomingWebhook.prototype.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: '#my-channel'
+          })
+        );
       });
     });
   });


### PR DESCRIPTION
For some reason I had a mental blank for a week or so on how Slack webhooks work, specifically that they have a "default" channel - while you can override this by explicitly passing a channel, it'll still come from the same webhook (meaning it'll have the same name, icon, etc).

This change removes the use of `SLACK_CHANNEL` to encourage having a webhook per env.