### PR TITLE
feat: add `resources.yml` file with example resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ all possible values supported by this file
 You can find a general introduction to AWS on Serverless
 [here](https://www.serverless.com/framework/docs/providers/aws/guide/intro/).
 
+Additional infrastructure is defined in `resources.yml`, which Serverless passes
+to CloudFormation to include as part of its Stack.
+
 #### Stages
 
 A "stage" in serverless is equivalent to what we typically refer to as an

--- a/resources.yml
+++ b/resources.yml
@@ -1,0 +1,5 @@
+# Put resources for CloudFormation to create in here
+#UploadsBucket:
+#  Type: AWS::S3::Bucket
+#  Properties:
+#    BucketName: ${self:custom.resources.uploadsBucket}

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,17 +21,17 @@ provider:
     blockPublicAccess: true # Prevents public access via ACLs or bucket policies.
     serverSideEncryption: AES256
     tags: # Tags that will be added to each of the deployment resources
-      ProvisionedBy: ${self:custom.commonValues.provisionedBy}
-      Project: ${self:custom.commonValues.project}
+      ProvisionedBy: ${self:custom.commonTags.provisionedBy}
+      Project: ${self:custom.commonTags.project}
   stackTags: # Optional CF stack tags
-    ProvisionedBy: ${self:custom.commonValues.provisionedBy}
-    Project: ${self:custom.commonValues.project}
+    ProvisionedBy: ${self:custom.commonTags.provisionedBy}
+    Project: ${self:custom.commonTags.project}
   tags: # service wide tags
-    ProvisionedBy: ${self:custom.commonValues.provisionedBy}
-    Project: ${self:custom.commonValues.project}
+    ProvisionedBy: ${self:custom.commonTags.provisionedBy}
+    Project: ${self:custom.commonTags.project}
     Owner: Ackama
 
-  stage: staging
+  stage: ${opt:stage, 'staging'}
 
   # These environment vars are installed into **all** functions in the service
   environment:
@@ -39,7 +39,10 @@ provider:
     SLACK_CHANNEL: ${env:SLACK_CHANNEL}
 
 custom:
-  commonValues:
+  resources:
+    prefix: ${self:service}-${self:provider.stage}
+    #uploadsBucket: ${self:custom.resources.prefix}-uploads
+  commonTags:
     provisionedBy: Serverless
     project: serverless-aws-template
   outDir: ${file(./tsconfig.build.json):compilerOptions.outDir}
@@ -93,3 +96,6 @@ functions:
       # https://serverless.com/framework/docs/providers/aws/events/sns/
       # to use a pre-existing SNS, provide an arn as the events name, or via the `arn` property
       - sns: my-sns-topic
+
+resources:
+  Resources: ${file(./resources.yml)}


### PR DESCRIPTION
Serverless is a bit odd (or maybe it's just me): they have support for `stage` as a provider variable and `--stage`, but seem to leave it up to you to connect the two. I realised the other day that we can do `${opt:stage, 'staging'}` at the provider level to avoid having to do it everywhere else.

This is on the back of adding `resources.yml`, with a commented out example resource. I found that doing this makes things a lot more readable compared to having everything shoved into the `serverless.yml`.

(This doesn't mean I've not decided on `serverless.ts` vs `serverless.yml` - I think this makes sense for either configs).