### PR TITLE
feat: update to use `nodejs14.x` runtime

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -49,7 +49,7 @@ jobs:
       - run: npm run typecheck
 
   test:
-    name: Test on ${{ matrix.os }} using Node.js v12
+    name: Test on ${{ matrix.os }} using Node.js v14
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/deploy-to-production.yaml
+++ b/.github/workflows/deploy-to-production.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/deploy-to-staging.yaml
+++ b/.github/workflows/deploy-to-staging.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - uses: actions/cache@v2
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -957,9 +957,9 @@
       }
     },
     "@serverless/platform-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-3.4.0.tgz",
-      "integrity": "sha512-iOMsluUqf7rQDalDwTRA+fuAHxk8WXCPXnMFDuTf/34q/1uRCx/xJhBNIvEUIbzZnSjiykfTIXUAcJ6kKbh6qA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-3.11.0.tgz",
+      "integrity": "sha512-fC4Q6mjARGdkPrBzEdsiZIgC4To74P7ro9qbtjhre1K9O0tJvvFB7/TuF3F7Xdry4fSPG6RuqdEDEXYA4FwkZw==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.4.13",
@@ -979,21 +979,6 @@
         "ws": "^7.2.1"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
-          "dev": true
-        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -1003,22 +988,34 @@
       }
     },
     "@serverless/platform-client-china": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.0.9.tgz",
-      "integrity": "sha512-qec3a5lVaMH0nccgjVgvcEF8M+M95BXZbbYDGypVHEieJQxrKqj057+VVKsiHBeHYXzr4B3v6pIyQHst40vpIw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.1.4.tgz",
+      "integrity": "sha512-jX+MoKgX7wkdg2lGUlUhbQNZLZkONs5jZa8edT+nDC8s9B1C5u5NO4mMuAy0ZigBQcfw/VVv2KvB06ntuw/QBA==",
       "dev": true,
       "requires": {
-        "@serverless/utils-china": "^1.0.11",
+        "@serverless/utils-china": "^1.0.14",
+        "adm-zip": "^0.5.1",
         "archiver": "^5.0.2",
+        "axios": "^0.21.1",
         "dotenv": "^8.2.0",
+        "fast-glob": "^3.2.4",
         "fs-extra": "^9.0.1",
         "https-proxy-agent": "^5.0.0",
         "js-yaml": "^3.14.0",
         "minimatch": "^3.0.4",
         "querystring": "^0.2.0",
+        "run-parallel-limit": "^1.0.6",
         "traverse": "^0.6.6",
         "urlencode": "^1.1.0",
         "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "adm-zip": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.2.tgz",
+          "integrity": "sha512-lUI3ZSNsfQXNYNzGjt68MdxzCs0eW29lgL74y/Y2h4nARgHmH3poFWuK3LonvFbNHFt4dTb2X/QQ4c1ZUWWsJw==",
+          "dev": true
+        }
       }
     },
     "@serverless/platform-sdk": {
@@ -1124,17 +1121,17 @@
       }
     },
     "@serverless/utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-2.2.0.tgz",
-      "integrity": "sha512-0TqmLwH9r2GAewvz9mhZ+TSyQBoE9ANuB4nNhn6lJvVUgzlzji3aqeFbAuDt+Z60ZkaIDNipU/J5Vf2Lo/QTQQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-HhmnTtfGt4gKCNGHg0q9pioltChh+dWbdA7y1aP7vNqjwpZ/pUDAqJf/M3GFozTnhlFpwCY9Ik1tOpDkgP3oiA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "inquirer": "^7.3.3",
         "js-yaml": "^4.0.0",
+        "jwt-decode": "^3.1.2",
         "lodash": "^4.17.20",
         "ncjsm": "^4.1.0",
-        "rc": "^1.2.8",
         "type": "^2.1.0",
         "uuid": "^8.3.2",
         "write-file-atomic": "^3.0.3"
@@ -1154,13 +1151,19 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "jwt-decode": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+          "dev": true
         }
       }
     },
     "@serverless/utils-china": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.12.tgz",
-      "integrity": "sha512-PuVap97QTf3Fi5+ez3ZUewGPFHTpf3dwZ+c6YWEoaf+1u7cgXzYFuWx8Ypi+4ghbL93/bf+blqdm+7CQi+CMRg==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.14.tgz",
+      "integrity": "sha512-7ku9ePjb+bneFV1Akmz0t8pU8hhHfPJsBjG/Kf6IjyGAQrEjN/PcY2QUDm0emdCNyCsuido1wp0DWMGiwuhC8Q==",
       "dev": true,
       "requires": {
         "@tencent-sdk/capi": "^1.1.2",
@@ -1388,9 +1391,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.167",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
-      "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==",
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
       "dev": true
     },
     "@types/long": {
@@ -1976,9 +1979,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.828.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.828.0.tgz",
-      "integrity": "sha512-JoDujGdncSIF9ka+XFZjop/7G+fNGucwPwYj7OHYMmFIOV5p7YmqomdbVmH/vIzd988YZz8oLOinWc4jM6vvhg==",
+      "version": "2.841.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.841.0.tgz",
+      "integrity": "sha512-pMgFr0B4WFIZEKc6EPAcyrvafkqoE1JwU6DJuE4UmT2ntat87DnbWUzFRP2HB4HuJvP1F7KNmElMz8p8j8bkNg==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -2223,9 +2226,9 @@
       }
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -2677,9 +2680,9 @@
       },
       "dependencies": {
         "fsevents": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-          "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
           "dev": true,
           "optional": true
         }
@@ -2987,9 +2990,9 @@
       }
     },
     "crc32-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
-      "integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
+      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
       "dev": true,
       "requires": {
         "crc-32": "^1.2.0",
@@ -3075,9 +3078,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.3.tgz",
-      "integrity": "sha512-/2fdLN987N8Ki7Id8BUN2nhuiRyxTLumQnSQf9CNncFCyqFsSKb9TNhzRYcC8K8eJSJOKvbvkImo/MKKhNi4iw==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
       "dev": true
     },
     "debug": {
@@ -3736,9 +3739,9 @@
           "dev": true
         },
         "ws": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
           "dev": true
         }
       }
@@ -4917,15 +4920,15 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       },
       "dependencies": {
         "jsonfile": {
@@ -4936,20 +4939,12 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
           }
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }
@@ -7747,9 +7742,9 @@
       }
     },
     "open": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
-      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.0.tgz",
+      "integrity": "sha512-PGoBCX/lclIWlpS/R2PQuIR4NJoXh6X5AwVzE7WXnWRGvHg7+4TBCgsujUgiPpm0K1y4qvQeWnCWVTpTKZBtvA==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -8241,9 +8236,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.40.tgz",
-          "integrity": "sha512-eKaRo87lu1yAXrzEJl0zcJxfUMDT5/mZalFyOkT44rnQps41eS2pfWzbaulSPpQLFNy29bFqn+Y5lOTL8ATlEQ==",
+          "version": "13.13.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.41.tgz",
+          "integrity": "sha512-qLT9IvHiXJfdrje9VmsLzun7cQ65obsBTmtU3EOnCSLFOoSHx1hpiRHoBnpdbyFqnzqdUUIv81JcEJQCB8un9g==",
           "dev": true
         },
         "long": {
@@ -8873,37 +8868,37 @@
       }
     },
     "serverless": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.19.0.tgz",
-      "integrity": "sha512-JvNB+llJXIfsMk6weTh5/aCMEvTGnizQ/ZHfyyXhLuBHm0cAa9h6bpyBagnC5CTtV++jwCR2WKu2a0SQQEmEvA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.23.0.tgz",
+      "integrity": "sha512-D5RN0ywVPxL4EFfIzREx9K7vgkHlXBQQn9zTfDzlfz2WHkmKX0kW3LG89J51UYNdeKlBN1YXPIphybzZH3ujOw==",
       "dev": true,
       "requires": {
         "@serverless/cli": "^1.5.2",
-        "@serverless/components": "^3.4.7",
+        "@serverless/components": "^3.6.0",
         "@serverless/enterprise-plugin": "^4.4.2",
-        "@serverless/utils": "^2.2.0",
+        "@serverless/utils": "^3.1.0",
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
         "archiver": "^5.2.0",
-        "aws-sdk": "^2.828.0",
+        "aws-sdk": "^2.839.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.0.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "child-process-ext": "^2.1.1",
         "d": "^1.0.1",
-        "dayjs": "^1.10.3",
+        "dayjs": "^1.10.4",
         "decompress": "^4.2.1",
         "dotenv": "^8.2.0",
         "download": "^8.0.0",
         "essentials": "^1.1.1",
         "fastest-levenshtein": "^1.0.12",
         "filesize": "^6.1.0",
-        "fs-extra": "^9.0.1",
+        "fs-extra": "^9.1.0",
         "get-stdin": "^8.0.0",
         "globby": "^11.0.2",
         "got": "^11.8.1",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.5",
         "https-proxy-agent": "^5.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0",
@@ -8931,15 +8926,15 @@
       },
       "dependencies": {
         "@serverless/components": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.4.7.tgz",
-          "integrity": "sha512-jY3+K3juQAa1HpFbvc1kztyDi4SFqG1+1GzUwh/kpRTlz2A01GnekWm8mf47l9HKxRzMxqVveg37wyyIQpw4xg==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.6.2.tgz",
+          "integrity": "sha512-JT8+t3J90WF/ZjizTbIUbmwzLJFAybP6S2T8TK9TtHl1imeeIIu69LcFAth7fFYdPn6LrACSEMZMXJ2+QlLM6w==",
           "dev": true,
           "requires": {
-            "@serverless/platform-client": "^3.1.5",
-            "@serverless/platform-client-china": "^2.0.9",
+            "@serverless/platform-client": "^3.9.1",
+            "@serverless/platform-client-china": "^2.1.0",
             "@serverless/platform-sdk": "^2.3.2",
-            "@serverless/utils": "^2.2.0",
+            "@serverless/utils": "^3.1.0",
             "adm-zip": "^0.4.16",
             "ansi-escapes": "^4.3.1",
             "aws4": "^1.11.0",
@@ -8953,7 +8948,6 @@
             "got": "^11.8.1",
             "graphlib": "^2.1.8",
             "https-proxy-agent": "^5.0.0",
-            "ini": "^1.3.8",
             "inquirer-autocomplete-prompt": "^1.3.0",
             "js-yaml": "^3.14.1",
             "memoizee": "^0.4.14",
@@ -8999,6 +8993,12 @@
             "merge2": "^1.3.0",
             "slash": "^3.0.0"
           }
+        },
+        "graceful-fs": {
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+          "dev": true
         },
         "ignore": {
           "version": "5.1.8",
@@ -9144,9 +9144,9 @@
       }
     },
     "simple-git": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.31.0.tgz",
-      "integrity": "sha512-/+rmE7dYZMbRAfEmn8EUIOwlM2G7UdzpkC60KF86YAfXGnmGtsPrKsym0hKvLBdFLLW019C+aZld1+6iIVy5xA==",
+      "version": "2.34.2",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.34.2.tgz",
+      "integrity": "sha512-/EX4FtcpAj5L/Bs5zgaBGYDrnkrKflFVNppNLH9VXpIjZBLHx5cZ6/mOYJCoKXKlLRuk3iTvzrIsHo7v42zWHg==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "prettier-config-ackama": "^0.1.2",
-    "serverless": "^2.19.0",
+    "serverless": "^2.23.0",
     "serverless-plugin-scripts": "^1.0.2",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,7 +10,7 @@ plugins:
 provider:
   name: aws
   region: ap-southeast-2
-  runtime: nodejs12.x
+  runtime: nodejs14.x
 
   apiGateway:
     shouldStartNameWithService: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES2020",
     "module": "CommonJS",
     "moduleResolution": "Node",
     "lib": ["ES2020"],


### PR DESCRIPTION
This lets us target `es2020`, which means [optional chaining (`?.`)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) & the [nullish coalescing operator (`??`)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) no longer have to be transpiled 🎉 