### PR TITLE
feat: use `NODE_OPTIONS` to register `source-map-support`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,8 +2397,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffermaker": {
       "version": "1.2.1",
@@ -9451,8 +9450,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -9471,7 +9469,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "prettier": "prettier-config-ackama",
   "dependencies": {
-    "@slack/webhook": "^6.0.0"
+    "@slack/webhook": "^6.0.0",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@jest/types": "^26.6.2",

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,6 +35,7 @@ provider:
 
   # These environment vars are installed into **all** functions in the service
   environment:
+    NODE_OPTIONS: '-r source-map-support/register'
     SLACK_WEBHOOK_URL: ${env:SLACK_WEBHOOK_URL}
     SLACK_CHANNEL: ${env:SLACK_CHANNEL}
 


### PR DESCRIPTION
This improves stack traces by having using the source maps via `source-map-support`.

While we can import `source-map-support`, using the register is *much* better because it ensures it is registered before anything else and it's already being used by `jest`, meaning stack traces in failed tests would get screwed up as it'd be doing the same work twice.

Before:

![image](https://user-images.githubusercontent.com/3151613/113491439-f4999800-9524-11eb-9ff5-0962215bf567.png)

After:

![image](https://user-images.githubusercontent.com/3151613/113491441-f8c5b580-9524-11eb-8c9f-013087924180.png)

Note that we do seem to lose the ability to see the code snippets, but I'm not too fussed about this as you can just follow along "at home" with the source code now that you'll be getting exact line numbers.

(I also think this is something that'll be improved or fixable down the line - in this particular case, I've not got the code in a repo that Sentry can see)