### PR TITLE
feat: update `serverless` and use new `package.patterns` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -918,32 +918,64 @@
       }
     },
     "@serverless/enterprise-plugin": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-4.4.2.tgz",
-      "integrity": "sha512-w5xD8R8tFK6B7QiLvWI5jqVHTtH1LdTyGp5eRcjkdJBa10/D2IZFpJimMAGsBxk9U1JGKO4j0miVnRHIW8ppeg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-4.5.3.tgz",
+      "integrity": "sha512-/JwlHoBSmxP8bAaWD3dIGePkJU1sLRHhEgvMyXuDo9i9tN5D6kyZypM2GUVNx4MpUR/XPJtCUgCSp5xI4aSsxg==",
       "dev": true,
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
-        "@serverless/platform-client": "^3.1.5",
-        "@serverless/platform-sdk": "^2.3.2",
+        "@serverless/platform-client": "^4.2.2",
+        "@serverless/utils": "^4.0.0",
         "chalk": "^4.1.0",
         "child-process-ext": "^2.1.1",
-        "chokidar": "^3.5.0",
+        "chokidar": "^3.5.1",
         "cli-color": "^2.0.0",
         "flat": "^5.0.2",
-        "fs-extra": "^9.0.1",
-        "js-yaml": "^3.14.1",
-        "jszip": "^3.5.0",
-        "lodash": "^4.17.20",
-        "memoizee": "^0.4.14",
+        "fs-extra": "^9.1.0",
+        "js-yaml": "^4.0.0",
+        "jszip": "^3.6.0",
+        "lodash": "^4.17.21",
+        "memoizee": "^0.4.15",
         "ncjsm": "^4.1.0",
         "node-dir": "^0.1.17",
         "node-fetch": "^2.6.1",
-        "open": "^7.3.0",
-        "semver": "^7.3.4",
-        "simple-git": "^2.31.0",
+        "open": "^7.4.2",
+        "semver": "^7.3.5",
+        "simple-git": "^2.37.0",
         "uuid": "^8.3.2",
         "yamljs": "^0.3.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@serverless/event-mocks": {
@@ -957,40 +989,66 @@
       }
     },
     "@serverless/platform-client": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-3.11.0.tgz",
-      "integrity": "sha512-fC4Q6mjARGdkPrBzEdsiZIgC4To74P7ro9qbtjhre1K9O0tJvvFB7/TuF3F7Xdry4fSPG6RuqdEDEXYA4FwkZw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.2.2.tgz",
+      "integrity": "sha512-8jP72e0POFGEW7HKtDzK0qt1amYtvlB7bYSal8JUCXbeY2qk3xRJZuLWCZBBKRGz4ha4eBNjlz7iniACb9biLg==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.4.13",
-        "archiver": "^5.0.0",
+        "archiver": "^5.3.0",
         "axios": "^0.21.1",
-        "fast-glob": "^3.2.4",
+        "fast-glob": "^3.2.5",
         "https-proxy-agent": "^5.0.0",
         "ignore": "^5.1.8",
         "isomorphic-ws": "^4.0.1",
         "js-yaml": "^3.13.1",
         "jwt-decode": "^2.2.0",
         "minimatch": "^3.0.4",
-        "querystring": "^0.2.0",
-        "run-parallel-limit": "^1.0.6",
+        "querystring": "^0.2.1",
+        "run-parallel-limit": "^1.1.0",
         "throat": "^5.0.0",
         "traverse": "^0.6.6",
-        "ws": "^7.2.1"
+        "ws": "^7.4.4"
       },
       "dependencies": {
+        "adm-zip": {
+          "version": "0.4.16",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+          "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
           "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
+        },
+        "ws": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+          "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+          "dev": true
         }
       }
     },
     "@serverless/platform-client-china": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.1.4.tgz",
-      "integrity": "sha512-jX+MoKgX7wkdg2lGUlUhbQNZLZkONs5jZa8edT+nDC8s9B1C5u5NO4mMuAy0ZigBQcfw/VVv2KvB06ntuw/QBA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.1.9.tgz",
+      "integrity": "sha512-PAqhHshlwY1PTeuwCaJeXfGB64w1Vg6C9FtpoFv7dkb7OAlYl86evJbugGUc4YlsdhQsgJvG3QSZpo7sYK1Ipw==",
       "dev": true,
       "requires": {
         "@serverless/utils-china": "^1.0.14",
@@ -1008,103 +1066,6 @@
         "traverse": "^0.6.6",
         "urlencode": "^1.1.0",
         "ws": "^7.3.1"
-      },
-      "dependencies": {
-        "adm-zip": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.2.tgz",
-          "integrity": "sha512-lUI3ZSNsfQXNYNzGjt68MdxzCs0eW29lgL74y/Y2h4nARgHmH3poFWuK3LonvFbNHFt4dTb2X/QQ4c1ZUWWsJw==",
-          "dev": true
-        }
-      }
-    },
-    "@serverless/platform-sdk": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-2.3.2.tgz",
-      "integrity": "sha512-JSX0/EphGVvnb4RAgZYewtBXPuVsU2TFCuXh6EEZ4jxK3WgUwNYeYdwB8EuVLrm1/dYqu/UWUC0rPKb+ZDycJg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.2",
-        "https-proxy-agent": "^4.0.0",
-        "is-docker": "^1.1.0",
-        "jwt-decode": "^2.2.0",
-        "node-fetch": "^2.6.1",
-        "opn": "^5.5.0",
-        "querystring": "^0.2.0",
-        "ramda": "^0.25.0",
-        "rc": "^1.2.8",
-        "regenerator-runtime": "^0.13.7",
-        "source-map-support": "^0.5.19",
-        "uuid": "^3.4.0",
-        "write-file-atomic": "^2.4.3",
-        "ws": "<7.0.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-          "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "5",
-            "debug": "4"
-          }
-        },
-        "is-docker": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-1.1.0.tgz",
-          "integrity": "sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=",
-          "dev": true
-        },
-        "ramda": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-          "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
       }
     },
     "@serverless/template": {
@@ -1121,18 +1082,18 @@
       }
     },
     "@serverless/utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-3.1.0.tgz",
-      "integrity": "sha512-HhmnTtfGt4gKCNGHg0q9pioltChh+dWbdA7y1aP7vNqjwpZ/pUDAqJf/M3GFozTnhlFpwCY9Ik1tOpDkgP3oiA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-4.0.1.tgz",
+      "integrity": "sha512-3/+Tw/kcIpBlrPyN244Ci7IZXVhGH9WLiLZcSwL0U96g0QQBofIGbv5v2h3Q6J4rBpPUOiZJcabJc7cIvlcP6Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "inquirer": "^7.3.3",
         "js-yaml": "^4.0.0",
         "jwt-decode": "^3.1.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "ncjsm": "^4.1.0",
-        "type": "^2.1.0",
+        "type": "^2.5.0",
         "uuid": "^8.3.2",
         "write-file-atomic": "^3.0.3"
       },
@@ -1156,6 +1117,12 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
           "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -1608,9 +1575,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w==",
       "dev": true
     },
     "after": {
@@ -1768,9 +1735,9 @@
       }
     },
     "archiver": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
-      "integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
+      "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -1778,8 +1745,8 @@
         "buffer-crc32": "^0.2.1",
         "readable-stream": "^3.6.0",
         "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.1.4",
-        "zip-stream": "^4.0.4"
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
       }
     },
     "archiver-utils": {
@@ -1954,12 +1921,6 @@
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1979,9 +1940,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.841.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.841.0.tgz",
-      "integrity": "sha512-pMgFr0B4WFIZEKc6EPAcyrvafkqoE1JwU6DJuE4UmT2ntat87DnbWUzFRP2HB4HuJvP1F7KNmElMz8p8j8bkNg==",
+      "version": "2.880.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.880.0.tgz",
+      "integrity": "sha512-/dBk3ejw22ED2edzGfmJB83KXDA4wLIw5Hb+2YMhly+gOWecvevy0tML2+YN/cmxyTy+wT0E0sM7fm1v7kmHtw==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -2010,6 +1971,12 @@
           "version": "1.1.13",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
           "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+          "dev": true
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
           "dev": true
         },
         "uuid": {
@@ -2848,9 +2815,9 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",
@@ -2913,9 +2880,9 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-      "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.0.tgz",
+      "integrity": "sha512-ofaaLqfraD1YRTkrRKPCrGJ1pFeDG/MVCkVVV2FNGeWquSlqw5wOrwOfPQ1xF2u+blpeWASie5EubHz+vsNIgA==",
       "dev": true,
       "requires": {
         "buffer-crc32": "^0.2.13",
@@ -3705,9 +3672,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
-      "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
+      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -3739,9 +3706,9 @@
           "dev": true
         },
         "ws": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+          "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
           "dev": true
         }
       }
@@ -4734,9 +4701,9 @@
       }
     },
     "fecha": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
-      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
       "dev": true
     },
     "figures": {
@@ -5185,9 +5152,9 @@
       }
     },
     "got": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-      "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^4.0.0",
@@ -5243,9 +5210,9 @@
           }
         },
         "defer-to-connect": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+          "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
           "dev": true
         },
         "get-stream": {
@@ -5285,9 +5252,9 @@
           "dev": true
         },
         "p-cancelable": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
+          "integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
           "dev": true
         },
         "responselike": {
@@ -5496,9 +5463,9 @@
       }
     },
     "http2-wrapper": {
-      "version": "1.0.0-beta.5.2",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
@@ -6846,9 +6813,9 @@
       }
     },
     "jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -7472,9 +7439,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
+      "integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7742,30 +7709,13 @@
       }
     },
     "open": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.0.tgz",
-      "integrity": "sha512-PGoBCX/lclIWlpS/R2PQuIR4NJoXh6X5AwVzE7WXnWRGvHg7+4TBCgsujUgiPpm0K1y4qvQeWnCWVTpTKZBtvA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
-      }
-    },
-    "opn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-      "dev": true,
-      "requires": {
-        "is-wsl": "^1.1.0"
-      },
-      "dependencies": {
-        "is-wsl": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-          "dev": true
-        }
       }
     },
     "optional": {
@@ -8236,9 +8186,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.41.tgz",
-          "integrity": "sha512-qLT9IvHiXJfdrje9VmsLzun7cQ65obsBTmtU3EOnCSLFOoSHx1hpiRHoBnpdbyFqnzqdUUIv81JcEJQCB8un9g==",
+          "version": "13.13.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.48.tgz",
+          "integrity": "sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==",
           "dev": true
         },
         "long": {
@@ -8295,9 +8245,15 @@
       }
     },
     "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
     "quick-lru": {
@@ -8387,12 +8343,6 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -8658,15 +8608,18 @@
       "dev": true
     },
     "run-parallel-limit": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.0.6.tgz",
-      "integrity": "sha512-yFFs4Q2kECi5mWXyyZj3UlAZ5OFq5E07opABC+EmhZdjEkrxXaUwFqOaaNF4tbayMnBxrsbujpeCYTVjGufZGQ==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -8868,24 +8821,25 @@
       }
     },
     "serverless": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.23.0.tgz",
-      "integrity": "sha512-D5RN0ywVPxL4EFfIzREx9K7vgkHlXBQQn9zTfDzlfz2WHkmKX0kW3LG89J51UYNdeKlBN1YXPIphybzZH3ujOw==",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.33.1.tgz",
+      "integrity": "sha512-NLRnK6376mAjGYnsfjr3UCIX8pH6US1hHow3ESRs+/ycIzRdG/LXlDAgq+4vLnPQ8t8vc9ZyU8FTFfrSR4sHqg==",
       "dev": true,
       "requires": {
         "@serverless/cli": "^1.5.2",
-        "@serverless/components": "^3.6.0",
-        "@serverless/enterprise-plugin": "^4.4.2",
-        "@serverless/utils": "^3.1.0",
+        "@serverless/components": "^3.8.1",
+        "@serverless/enterprise-plugin": "^4.5.3",
+        "@serverless/utils": "^4.0.1",
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
-        "archiver": "^5.2.0",
-        "aws-sdk": "^2.839.0",
+        "archiver": "^5.3.0",
+        "aws-sdk": "^2.879.0",
         "bluebird": "^3.7.2",
         "boxen": "^5.0.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "child-process-ext": "^2.1.1",
+        "ci-info": "^3.1.1",
         "d": "^1.0.1",
         "dayjs": "^1.10.4",
         "decompress": "^4.2.1",
@@ -8896,16 +8850,16 @@
         "filesize": "^6.1.0",
         "fs-extra": "^9.1.0",
         "get-stdin": "^8.0.0",
-        "globby": "^11.0.2",
-        "got": "^11.8.1",
-        "graceful-fs": "^4.2.5",
+        "globby": "^11.0.3",
+        "got": "^11.8.2",
+        "graceful-fs": "^4.2.6",
         "https-proxy-agent": "^5.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0",
         "js-yaml": "^4.0.0",
         "json-cycle": "^1.3.0",
         "json-refs": "^3.0.15",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "memoizee": "^0.4.15",
         "micromatch": "^4.0.2",
         "ncjsm": "^4.1.0",
@@ -8914,38 +8868,34 @@
         "p-limit": "^3.1.0",
         "promise-queue": "^2.2.5",
         "replaceall": "^0.1.6",
-        "semver": "^7.3.4",
+        "semver": "^7.3.5",
         "tabtab": "^3.0.2",
         "tar": "^6.1.0",
         "timers-ext": "^0.1.7",
-        "type": "^2.1.0",
+        "type": "^2.5.0",
         "untildify": "^4.0.0",
         "uuid": "^8.3.2",
-        "yaml-ast-parser": "0.0.43",
-        "yargs-parser": "^20.2.4"
+        "yaml-ast-parser": "0.0.43"
       },
       "dependencies": {
         "@serverless/components": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.6.2.tgz",
-          "integrity": "sha512-JT8+t3J90WF/ZjizTbIUbmwzLJFAybP6S2T8TK9TtHl1imeeIIu69LcFAth7fFYdPn6LrACSEMZMXJ2+QlLM6w==",
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.8.1.tgz",
+          "integrity": "sha512-GgIsO/8fKz4tS6y7W4j90EHacyR3XkssVQncEpMt4e8gfAlr3JZBZVka2fO29Ehhx3xYxqDDWBkcVKRzPf8Iaw==",
           "dev": true,
           "requires": {
-            "@serverless/platform-client": "^3.9.1",
-            "@serverless/platform-client-china": "^2.1.0",
-            "@serverless/platform-sdk": "^2.3.2",
+            "@serverless/platform-client": "^4.2.2",
+            "@serverless/platform-client-china": "^2.1.9",
             "@serverless/utils": "^3.1.0",
-            "adm-zip": "^0.4.16",
+            "adm-zip": "^0.5.4",
             "ansi-escapes": "^4.3.1",
-            "aws4": "^1.11.0",
             "chalk": "^4.1.0",
             "child-process-ext": "^2.1.1",
-            "chokidar": "^3.5.0",
+            "chokidar": "^3.5.1",
             "dotenv": "^8.2.0",
             "figures": "^3.2.0",
-            "fs-extra": "^9.0.1",
-            "globby": "^11.0.2",
-            "got": "^11.8.1",
+            "fs-extra": "^9.1.0",
+            "got": "^11.8.2",
             "graphlib": "^2.1.8",
             "https-proxy-agent": "^5.0.0",
             "inquirer-autocomplete-prompt": "^1.3.0",
@@ -8962,6 +8912,34 @@
             "uuid": "^8.3.2"
           },
           "dependencies": {
+            "@serverless/utils": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-3.1.0.tgz",
+              "integrity": "sha512-HhmnTtfGt4gKCNGHg0q9pioltChh+dWbdA7y1aP7vNqjwpZ/pUDAqJf/M3GFozTnhlFpwCY9Ik1tOpDkgP3oiA==",
+              "dev": true,
+              "requires": {
+                "chalk": "^4.1.0",
+                "inquirer": "^7.3.3",
+                "js-yaml": "^4.0.0",
+                "jwt-decode": "^3.1.2",
+                "lodash": "^4.17.20",
+                "ncjsm": "^4.1.0",
+                "type": "^2.1.0",
+                "uuid": "^8.3.2",
+                "write-file-atomic": "^3.0.3"
+              },
+              "dependencies": {
+                "js-yaml": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+                  "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+                  "dev": true,
+                  "requires": {
+                    "argparse": "^2.0.1"
+                  }
+                }
+              }
+            },
             "js-yaml": {
               "version": "3.14.1",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -8970,9 +8948,32 @@
               "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
+              },
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.10",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+                  "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+                  "dev": true,
+                  "requires": {
+                    "sprintf-js": "~1.0.2"
+                  }
+                }
               }
             }
           }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "ci-info": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.1.1.tgz",
+          "integrity": "sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==",
+          "dev": true
         },
         "get-stdin": {
           "version": "8.0.0",
@@ -8981,9 +8982,9 @@
           "dev": true
         },
         "globby": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -9013,15 +9014,19 @@
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-              "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-              "dev": true
-            }
           }
+        },
+        "jwt-decode": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
         },
         "p-limit": {
           "version": "3.1.0",
@@ -9038,11 +9043,14 @@
           "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
           "dev": true
         },
-        "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-          "dev": true
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -9144,14 +9152,25 @@
       }
     },
     "simple-git": {
-      "version": "2.34.2",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.34.2.tgz",
-      "integrity": "sha512-/EX4FtcpAj5L/Bs5zgaBGYDrnkrKflFVNppNLH9VXpIjZBLHx5cZ6/mOYJCoKXKlLRuk3iTvzrIsHo7v42zWHg==",
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.37.0.tgz",
+      "integrity": "sha512-ZK6qRnP+Xa2v23UEZDNHUfzswsuNCDHOQpWZRkpqNaXn7V5wVBBx3zRJLji3pROJGzrzA7mXwY7preL5EKuAaQ==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "simple-swizzle": {
@@ -10413,9 +10432,9 @@
       "dev": true
     },
     "type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+      "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
       "dev": true
     },
     "type-check": {
@@ -10557,6 +10576,12 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
           "dev": true
         }
       }
@@ -11085,13 +11110,13 @@
       "dev": true
     },
     "zip-stream": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-      "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
+      "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.0.2",
+        "compress-commons": "^4.1.0",
         "readable-stream": "^3.6.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "prettier-config-ackama": "^0.1.2",
-    "serverless": "^2.23.0",
+    "serverless": "^2.33.1",
     "serverless-plugin-scripts": "^1.0.2",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",

--- a/serverless.yml
+++ b/serverless.yml
@@ -54,15 +54,34 @@ custom:
       'before:deploy:function:packageFunction': *prepareForPacking
 
 package:
-  include:
+  patterns:
+    - '!**/*'
+    - 'package.json'
+    - 'node_modules/**'
+    - '!node_modules/@types/**'
+    - '!**/tsconfig*.json'
+    - '!**/*.d.ts'
+    - '!**/*.gradle'
+    - '!**/*.h'
+    - '!**/*.html'
+    - '!**/*.java'
+    - '!**/*.m'
+    - '!**/*.map'
+    - '!**/*.md'
+    - '!**/*.npmignore'
+    - '!**/*.pbxproj'
+    - '!**/*.pem'
+    - '!**/*.podspec'
+    - '!**/*.ts'
+    - '!**/*.tsbuildinfo'
+    - '!**/*.txt'
+    - '!**/*.un~'
+    - '!**/*.xcworkspacedata'
+    - '!**/*.xml'
+    - '!**/*.yml'
+    - '!**/Makefile'
+    - '!**/node_modules/.package-lock.json'
     - ${self:custom.outDir}/**/*
-    - package.json
-  exclude:
-    - '**/*'
-    - '!node_modules/**'
-    - '**/*.d.ts'
-    - '**/*.md'
-
 functions:
   api-lambda:
     handler: ${self:custom.outDir}/api-lambda/index.handler


### PR DESCRIPTION
`package.patterns` has replaced `package.include` & `package.exclude`.

Also chucked in a bunch of excludes for common files that exist in npm packages that are not needed; this usually shaves off a decent amount of size from the final zip package.

This exclusion takes place *after* dev packages are excluded.